### PR TITLE
Print out help when run with "-h"

### DIFF
--- a/bashmarks.sh
+++ b/bashmarks.sh
@@ -70,10 +70,23 @@ function d {
     fi
 }
 
+# print out help for the forgetful
+function help {
+    echo 's <bookmark_name> - Saves the current directory as "bookmark_name"'
+    echo 'g <bookmark_name> - Goes (cd) to the directory associated with "bookmark_name"'
+    echo 'p <bookmark_name> - Prints the directory associated with "bookmark_name"'
+    echo 'd <bookmark_name> - Deletes the bookmark'
+    echo 'l                 - Lists all available bookmarks'
+}
+
 # list bookmarks with dirnam
 function l {
-    source $SDIRS
-    env | grep "^DIR_" | cut -c5- | grep "^.*="
+    if [ "$1" = "-h" ] || [ "$1" = "-help" ] || [ "$1" = "--help" ] ; then
+        help
+    else
+        source $SDIRS
+        env | grep "^DIR_" | cut -c5- | grep "^.*="
+    fi
 }
 # list bookmarks without dirname
 function _l {


### PR DESCRIPTION
As I am pretty bad about remembering all command arguments, I thought it would be useful to print out help when l is given "-h" or "-help" or "--help" as it's argument. This could also be added to the other functions as well, though I think it's most useful with l.
