### PR TITLE
Small change to awk regex.

### DIFF
--- a/bashmarks.sh
+++ b/bashmarks.sh
@@ -92,7 +92,7 @@ function l {
     source $SDIRS
         
     # if color output is not working for you, comment out the line below '\033[1;32m' == "red"
-    env | sort | awk '/DIR_.+/{split(substr($0,5),parts,"="); printf("\033[1;31m%-20s\033[0m %s\n", parts[1], parts[2]);}'
+    env | sort | awk '/^DIR_/{split(substr($0,5),parts,"="); printf("\033[1;31m%-20s\033[0m %s\n", parts[1], parts[2]);}'
     
     # uncomment this line if color output is not working with the line above
     # env | grep "^DIR_" | cut -c5- | sort |grep "^.*=" 


### PR DESCRIPTION
awk needed ^ at start of regex. Didn't need .+ at end.
(Again: hope I'm following proper protocol here. Apologies if otherwise.)