### PR TITLE
Added support for whitespace in paths.

### DIFF
--- a/bashmarks.sh
+++ b/bashmarks.sh
@@ -44,7 +44,6 @@ function s {
     _bookmark_name_valid "$@"
     if [ -z "$exit_message" ]; then
         _purge_line "$SDIRS" "export DIR_$1="
-        # CURDIR=$(echo $PWD| sed "s#^$HOME#\$HOME#g")
 	CURDIR=$(echo $PWD | sed "s#^$HOME#\$HOME#g" | sed "s/ /\ /g")
         echo "export DIR_$1=\"$CURDIR\"" >> $SDIRS
     fi


### PR DESCRIPTION
Saving paths with whitespace in them would be substringed/trimmed after the first space. 

For example: "~/foo/bar/chocolate cookies from hell" would be saved as "$HOME/foo/bar/chocolate". 
Don't know if my solution is the best, but it works.  
