### PR TITLE
Added 'Moving to <target>' and '<target> does not exist' messages when using g

### DIFF
--- a/bashmarks.sh
+++ b/bashmarks.sh
@@ -38,6 +38,9 @@ if [ ! -n "$SDIRS" ]; then
 fi
 touch $SDIRS
 
+RED="0;31m"
+GREEN="0;33m"
+
 # save current directory to bookmarks
 function s {
     check_help $1
@@ -53,7 +56,13 @@ function s {
 function g {
     check_help $1
     source $SDIRS
-    cd "$(eval $(echo echo $(echo \$DIR_$1)))"
+    target="$(eval $(echo echo $(echo \$DIR_$1)))"
+    if [ -n "$target" ]; then
+        echo -e "\033[${GREEN}Moving to ${target}\033[00m"
+        cd "$target"
+    else
+        echo -e "\033[${RED}${1} does not exist\033[00m"
+    fi
 }
 
 # print bookmark
@@ -92,7 +101,7 @@ function l {
     source $SDIRS
         
     # if color output is not working for you, comment out the line below '\033[1;32m' == "red"
-    env | sort | awk '/DIR_.+/{split(substr($0,5),parts,"="); printf("\033[1;31m%-20s\033[0m %s\n", parts[1], parts[2]);}'
+    env | sort | awk '/DIR_.+/{split(substr($0,5),parts,"="); printf("\033[0;33m%-20s\033[0m %s\n", parts[1], parts[2]);}'
     
     # uncomment this line if color output is not working with the line above
     # env | grep "^DIR_" | cut -c5- | sort |grep "^.*=" 


### PR DESCRIPTION
Added 'Moving to <target>' and '<target> does not exist' messages when using `g`. 
Change colour ouput of `g` from red to green (as not error)

See screenshot:
![bashmarks updated g](https://f.cloud.github.com/assets/111275/199677/01f4e798-8098-11e2-842d-2ff22c8dc625.png)
