### PR TITLE
Fix env var pattern.

### DIFF
--- a/bashmarks.sh
+++ b/bashmarks.sh
@@ -102,7 +102,7 @@ function l {
     source $SDIRS
         
     # if color output is not working for you, comment out the line below '\033[1;32m' == "red"
-    env | sort | awk '/DIR_.+/{split(substr($0,5),parts,"="); printf("\033[0;33m%-20s\033[0m %s\n", parts[1], parts[2]);}'
+    env | sort | awk '/^DIR_.+/{split(substr($0,5),parts,"="); printf("\033[0;33m%-20s\033[0m %s\n", parts[1], parts[2]);}'
     
     # uncomment this line if color output is not working with the line above
     # env | grep "^DIR_" | cut -c5- | sort |grep "^.*=" 


### PR DESCRIPTION
Before the regex for matching environment variables was to allowing. For
example if you had a variable

export A_DIR=yadyade

it would be listed with the l() function as the pattern did match this
variable.