### PR TITLE
changing g link to go link for collision probleme w/ ZSH git plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ install:
 	@echo 'USAGE:'
 	@echo '------'
 	@echo 's <bookmark_name> - Saves the current directory as "bookmark_name"'
-	@echo 'g <bookmark_name> - Goes (cd) to the directory associated with "bookmark_name"'
+	@echo 'go <bookmark_name> - Goes (cd) to the directory associated with "bookmark_name"'
 	@echo 'p <bookmark_name> - Prints the directory associated with "bookmark_name"'
 	@echo 'd <bookmark_name> - Deletes the bookmark'
 	@echo 'l                 - Lists all available bookmarks'

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## Shell Commands
 
     s <bookmark_name> - Saves the current directory as "bookmark_name"
-    g <bookmark_name> - Goes (cd) to the directory associated with "bookmark_name"
+    go <bookmark_name> - Goes (cd) to the directory associated with "bookmark_name"
     p <bookmark_name> - Prints the directory associated with "bookmark_name"
     d <bookmark_name> - Deletes the bookmark
     l                 - Lists all available bookmarks
@@ -22,8 +22,8 @@
     $ cd /usr/local/lib/
     $ s locallib
     $ l
-    $ g web<tab>
-    $ g webfolder
+    $ go web<tab>
+    $ go webfolder
 
 ## Where Bashmarks are stored
     

--- a/bashmarks.sh
+++ b/bashmarks.sh
@@ -24,8 +24,8 @@
 
 # USAGE: 
 # s bookmarkname - saves the curr dir as bookmarkname
-# g bookmarkname - jumps to the that bookmark
-# g b[TAB] - tab completion is available
+# go bookmarkname - jumps to the that bookmark
+# go b[TAB] - tab completion is available
 # p bookmarkname - prints the bookmark
 # p b[TAB] - tab completion is available
 # d bookmarkname - deletes the bookmark
@@ -53,7 +53,7 @@ function s {
 }
 
 # jump to bookmark
-function g {
+function go {
     check_help $1
     source $SDIRS
     target="$(eval $(echo echo $(echo \$DIR_$1)))"
@@ -158,12 +158,12 @@ function _purge_line {
 
 # bind completion command for g,p,d to _comp
 if [ $ZSH_VERSION ]; then
-    compctl -K _compzsh g
+    compctl -K _compzsh go
     compctl -K _compzsh p
     compctl -K _compzsh d
 else
     shopt -s progcomp
-    complete -F _comp g
+    complete -F _comp go
     complete -F _comp p
     complete -F _comp d
 fi


### PR DESCRIPTION
Hi,
when using ZSH with his Git alias plugin, the g alias is already taken to link Git command.
Chaging "g" to "go"