### PR TITLE
Add quotes to allow paths with spaces in base path

### DIFF
--- a/bashmarks.sh
+++ b/bashmarks.sh
@@ -36,7 +36,7 @@
 if [ ! -n "$SDIRS" ]; then
     SDIRS=~/.sdirs
 fi
-touch $SDIRS
+touch "$SDIRS"
 
 RED="0;31m"
 GREEN="0;33m"


### PR DESCRIPTION
The original `touch $SDIRS` command fails if a user has a path with spaces. This isn't super common, but has happened to me on one of my machines, found this fix, and thought it'd be a good thing to add. 