### PR TITLE
Allow the installation directory to be specified externally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-INSTALL_DIR=~/.local/bin
+ifndef INSTALL_DIR
+    INSTALL_DIR=~/.local/bin
+    @echo "Setting INSTALL_DIR -> $(INSTALL_DIR)"
+endif
 
 all:
 	@echo "Please run 'make install'"


### PR DESCRIPTION
Current version mandates installation in .local.  This change
would allow the script to be installed in say /usr/loca/bin