### PR TITLE
A proper help function with "h"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,5 +17,6 @@ install:
 	@echo 'p <bookmark_name> - Prints the directory associated with "bookmark_name"'
 	@echo 'd <bookmark_name> - Deletes the bookmark'
 	@echo 'l                 - Lists all available bookmarks'
+	@echo 'h                 - Displays this help message'
 
 .PHONY: all install

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
     p <bookmark_name> - Prints the directory associated with "bookmark_name"
     d <bookmark_name> - Deletes the bookmark
     l                 - Lists all available bookmarks
+    h                 - Displays this help message
     
 ## Example Usage
 

--- a/bashmarks.sh
+++ b/bashmarks.sh
@@ -86,12 +86,7 @@ function d {
 # print out help for the forgetful
 function check_help {
     if [ "$1" = "-h" ] || [ "$1" = "-help" ] || [ "$1" = "--help" ] ; then
-        echo ''
-        echo 's <bookmark_name> - Saves the current directory as "bookmark_name"'
-        echo 'g <bookmark_name> - Goes (cd) to the directory associated with "bookmark_name"'
-        echo 'p <bookmark_name> - Prints the directory associated with "bookmark_name"'
-        echo 'd <bookmark_name> - Deletes the bookmark'
-        echo 'l                 - Lists all available bookmarks'
+        h
         kill -SIGINT $$
     fi
 }
@@ -107,6 +102,17 @@ function l {
     # uncomment this line if color output is not working with the line above
     # env | grep "^DIR_" | cut -c5- | sort |grep "^.*=" 
 }
+
+# show help
+function h {
+    echo ''
+    echo 's <bookmark_name> - Saves the current directory as "bookmark_name"'
+    echo 'g <bookmark_name> - Goes (cd) to the directory associated with "bookmark_name"'
+    echo 'p <bookmark_name> - Prints the directory associated with "bookmark_name"'
+    echo 'd <bookmark_name> - Deletes the bookmark'
+    echo 'l                 - Lists all available bookmarks'
+}
+
 # list bookmarks without dirname
 function _l {
     source $SDIRS


### PR DESCRIPTION
Currently help has to be accessed from options like `l -h` or `s --help`, which is fine, but a dedicated help function is much appreciated.