### PR TITLE
Fix _purge_line when noclobber is enabled

### DIFF
--- a/bashmarks.sh
+++ b/bashmarks.sh
@@ -100,10 +100,10 @@ function check_help {
 function l {
     check_help $1
     source $SDIRS
-        
+
     # if color output is not working for you, comment out the line below '\033[1;32m' == "red"
     env | sort | awk '/^DIR_.+/{split(substr($0,5),parts,"="); printf("\033[0;33m%-20s\033[0m %s\n", parts[1], parts[2]);}'
-    
+
     # uncomment this line if color output is not working with the line above
     # env | grep "^DIR_" | cut -c5- | sort |grep "^.*=" 
 }
@@ -142,17 +142,7 @@ function _compzsh {
 # safe delete line from sdirs
 function _purge_line {
     if [ -s "$1" ]; then
-        # safely create a temp file
-        t=$(mktemp -t bashmarks.XXXXXX) || exit 1
-        trap "/bin/rm -f -- '$t'" EXIT
-
-        # purge line
-        sed "/$2/d" "$1" >| "$t"
-        /bin/mv "$t" "$1"
-
-        # cleanup temp file
-        /bin/rm -f -- "$t"
-        trap - EXIT
+        sed -i "/$2/d" "$1"
     fi
 }
 

--- a/bashmarks.sh
+++ b/bashmarks.sh
@@ -147,7 +147,7 @@ function _purge_line {
         trap "/bin/rm -f -- '$t'" EXIT
 
         # purge line
-        sed "/$2/d" "$1" > "$t"
+        sed "/$2/d" "$1" >| "$t"
         /bin/mv "$t" "$1"
 
         # cleanup temp file

--- a/bashmarks.sh
+++ b/bashmarks.sh
@@ -142,7 +142,9 @@ function _compzsh {
 # safe delete line from sdirs
 function _purge_line {
     if [ -s "$1" ]; then
-        sed -i "/$2/d" "$1"
+        t=$(mktemp "${TMPDIR:-/tmp}/bashmarks.XXXXXX")
+        grep -v "$2" "$1" > "$t"
+        mv "$t" "$1"
     fi
 }
 


### PR DESCRIPTION
## Summary

This PR fixes a failure in `_purge_line` when Bash is configured with `set -o noclobber` (or `set -C`).

The previous implementation could fail while updating the bookmarks file because of the way the temporary file was created and written. As a result, commands that remove or update bookmarks would not work correctly in shells with `noclobber` enabled.

## Changes

* Simplified `_purge_line`.
* Replaced the previous `sed`-based temporary file workflow with a `grep -v` filter.
* Continue using `mktemp` for secure temporary file creation before replacing the original file.

## Why

Many users enable `noclobber` in their `.bashrc` or `.bash_profile` to prevent accidental file overwrites. This change makes `bashmarks` behave correctly in that configuration without requiring users to disable the option.

## Testing

Tested by enabling:

```bash
set -o noclobber
```

and verifying that bookmark removal/update operations complete successfully.
